### PR TITLE
Fixing missing SPI include for tftbmp examples

### DIFF
--- a/examples/tftbmp/tftbmp.pde
+++ b/examples/tftbmp/tftbmp.pde
@@ -6,6 +6,7 @@
 #include <Adafruit_GFX.h>    // Core graphics library
 #include <Adafruit_TFTLCD.h> // Hardware-specific library
 #include <SD.h>
+#include <SPI.h>
 
 // The control pins for the LCD can be assigned to any digital or
 // analog pins...but we'll use the analog pins as this allows us to
@@ -38,6 +39,16 @@
 
 // our TFT wiring
 Adafruit_TFTLCD tft(LCD_CS, LCD_CD, LCD_WR, LCD_RD, A4);
+uint8_t spi_save;
+
+void disableSPI(void) {
+  spi_save = SPCR;
+  SPCR = 0;
+}
+
+void enableSPI(void) {
+  SPCR = spi_save; 
+}
 
 void setup()
 {
@@ -73,9 +84,14 @@ void setup()
     return;
   }
   Serial.println(F("OK!"));
+  spi_save = SPCR;
 
-  bmpDraw("woof.bmp", 0, 0);
-  delay(1000);
+  disableSPI();    // release SPI so we can use those pins to draw
+ 
+  tft.setRotation(3);
+  bmpDraw("tiger.bmp", 0, 0);
+  // disable the SD card interface after we are done!
+  disableSPI();
 }
 
 void loop()

--- a/examples/tftbmp_shield/tftbmp_shield.pde
+++ b/examples/tftbmp_shield/tftbmp_shield.pde
@@ -6,6 +6,7 @@
 #include <Adafruit_GFX.h>    // Core graphics library
 #include <Adafruit_TFTLCD.h> // Hardware-specific library
 #include <SD.h>
+#include <SPI.h>
 
 // In the SD card, place 24 bit color BMP files (be sure they are 24-bit!)
 // There are examples in the sketch folder
@@ -13,7 +14,16 @@
 #define SD_CS 5 // Card select for shield use
 
 Adafruit_TFTLCD tft;
-uint8_t         spi_save;
+uint8_t spi_save;
+
+void disableSPI(void) {
+  spi_save = SPCR;
+  SPCR = 0;
+}
+
+void enableSPI(void) {
+  SPCR = spi_save; 
+}
 
 void setup()
 {
@@ -51,20 +61,16 @@ void setup()
   Serial.println(F("OK!"));
   spi_save = SPCR;
 
-  bmpDraw("woof.bmp", 0, 0);
-  delay(1000);
+  disableSPI();    // release SPI so we can use those pins to draw
+ 
+  tft.setRotation(3);
+  bmpDraw("tiger.bmp", 0, 0);
+  // disable the SD card interface after we are done!
+  disableSPI();
 }
 
 void loop()
 {
-  for(int i = 0; i<4; i++) {
-    tft.setRotation(i);
-    tft.fillScreen(0);
-    for(int j=0; j <= 200; j += 50) {
-      bmpDraw("miniwoof.bmp", j, j);
-    }
-    delay(1000);
-  }
 }
 
 // This function opens a Windows Bitmap (BMP) file and
@@ -222,4 +228,3 @@ uint32_t read32(File f) {
   ((uint8_t *)&result)[3] = f.read(); // MSB
   return result;
 }
-


### PR DESCRIPTION
Fixed the filename to line up with the [2.8"tft example](http://learn.adafruit.com/2-8-tft-touch-shield/bitmaps)

Without the SPI.h include the errors become:

```
Arduino: 1.5.4 (Windows NT (unknown)), Board: "Arduino Uno"

C:\Program Files (x86)\Arduino\libraries\SD\utility\Sd2Card.cpp: In function 'void spiSend(uint8_t)':
C:\Program Files (x86)\Arduino\libraries\SD\utility\Sd2Card.cpp:54: error: 'SPI' was not declared in this scope
C:\Program Files (x86)\Arduino\libraries\SD\utility\Sd2Card.cpp: In function 'uint8_t spiRec()':
C:\Program Files (x86)\Arduino\libraries\SD\utility\Sd2Card.cpp:81: error: 'SPI' was not declared in this scope
C:\Program Files (x86)\Arduino\libraries\SD\utility\Sd2Card.cpp: In member function 'uint8_t Sd2Card::init(uint8_t, uint8_t, int8_t, int8_t, int8_t)':
C:\Program Files (x86)\Arduino\libraries\SD\utility\Sd2Card.cpp:326: error: 'SPI' was not declared in this scope
C:\Program Files (x86)\Arduino\libraries\SD\utility\Sd2Card.cpp: In member function 'uint8_t Sd2Card::setSckRate(uint8_t)':
C:\Program Files (x86)\Arduino\libraries\SD\utility\Sd2Card.cpp:585: error: 'SPI' was not declared in this scope

  This report would have more information with
  "Show verbose output during compilation"
  enabled in File > Preferences.

```
