### PR TITLE
Update pin_magic.h

### DIFF
--- a/pin_magic.h
+++ b/pin_magic.h
@@ -279,7 +279,7 @@
    PIO_Clear(PIOB, (((~d) & 0x20)<<(27-5))); \
    WR_STROBE; }
 
-  #define read8inline(result) { \    
+  #define read8inline(result) { \
    RD_ACTIVE;   \
    delayMicroseconds(1);      \
    result = (((PIOC->PIO_PDSR & (1<<23)) >> (23-7)) | ((PIOC->PIO_PDSR & (1<<24)) >> (24-6)) | \


### PR DESCRIPTION
Extraneous spaces removed at the end of line 282 to correct this error:

In file included from /Users/.../Documents/Arduino/libraries/TFTLCD-Library-master/Adafruit_TFTLCD.cpp:19:0:
/Users/.../Documents/Arduino/libraries/TFTLCD-Library-master/pin_magic.h:282:33: warning: backslash and newline separated by space [enabled by default]
   #define read8inline(result) { \  
 ^
