### PR TITLE
ILI9325/8 bug: negative X2 coordinate

### DIFF
--- a/Adafruit_TFTLCD.cpp
+++ b/Adafruit_TFTLCD.cpp
@@ -393,6 +393,7 @@ void Adafruit_TFTLCD::setAddrWindow(int x1, int y1, int x2, int y2) {
      case 1:
       t  = y1;
       y1 = x1;
+      if ( y2>(TFTWIDTH-1) ) y2 = (TFTWIDTH-1);
       x1 = TFTWIDTH  - 1 - y2;
       y2 = x2;
       x2 = TFTWIDTH  - 1 - t;
@@ -413,6 +414,7 @@ void Adafruit_TFTLCD::setAddrWindow(int x1, int y1, int x2, int y2) {
       t  = x1;
       x1 = y1;
       y1 = TFTHEIGHT - 1 - x2;
+      if ( y2>(TFTWIDTH-1) ) y2 = (TFTWIDTH-1);
       x2 = y2;
       y2 = TFTHEIGHT - 1 - t;
       x  = x1;


### PR DESCRIPTION
ILI9325/8: When values 1 or 3 are passed to function setRotation(), the function setAddrWindow() will produce negative X2 coordinate.
This will hinder fillScreen() to set the screen black.