### PR TITLE
Solve warning "backslash and newline separated by space #34"

### DIFF
--- a/pin_magic.h
+++ b/pin_magic.h
@@ -279,7 +279,7 @@
    PIO_Clear(PIOB, (((~d) & 0x20)<<(27-5))); \
    WR_STROBE; }
 
-  #define read8inline(result) { \    
+  #define read8inline(result) { \
    RD_ACTIVE;   \
    delayMicroseconds(1);      \
    result = (((PIOC->PIO_PDSR & (1<<23)) >> (23-7)) | ((PIOC->PIO_PDSR & (1<<24)) >> (24-6)) | \


### PR DESCRIPTION
C:\Program Files (x86)\Arduino\libraries\Adafruit_TFTLCD\pin_magic.h:282:33: warning: backslash and newline separated by space