### PR TITLE
add: readPixel for ILI9341

### DIFF
--- a/Adafruit_TFTLCD.cpp
+++ b/Adafruit_TFTLCD.cpp
@@ -867,6 +867,25 @@ uint16_t Adafruit_TFTLCD::readPixel(int16_t x, int16_t y) {
     return (((uint16_t)r & B11111000) << 8) |
            (((uint16_t)g & B11111100) << 3) |
            (           b              >> 3);
+  } else if(driver == ID_9341) {
+
+    uint8_t r, g, b;
+
+    setAddrWindow( x,y,x,y);
+    CS_ACTIVE;
+    CD_COMMAND;
+    write8( ILI9341_MEMORYREAD);
+    setReadDir();  // Set up LCD data port(s) for READ operations
+    CD_DATA;
+    read8(r);      // First byte back is a dummy read
+    read8(r);
+    read8(g);
+    read8(b);
+    setWriteDir(); // Restore LCD data port(s) to WRITE configuration
+    CS_IDLE;
+    return (((uint16_t)r & B11111000) << 8) |
+           (((uint16_t)g & B11111100) << 3) |
+           (           b              >> 3);
   } else return 0;
 }
 

--- a/registers.h
+++ b/registers.h
@@ -74,6 +74,7 @@
 #define ILI9341_COLADDRSET         0x2A
 #define ILI9341_PAGEADDRSET        0x2B
 #define ILI9341_MEMORYWRITE        0x2C
+#define ILI9341_MEMORYREAD         0x2E
 #define ILI9341_PIXELFORMAT        0x3A
 #define ILI9341_FRAMECONTROL       0xB1
 #define ILI9341_DISPLAYFUNC        0xB6


### PR DESCRIPTION
Hi all!

I added the missing code for readPixel on ILI9341 displays.
The code is tested on hardware and was used for a 'screenshot' function.

Best regards,
Bert