### PR TITLE
Fixed Compilation issue due to not datatype assigned for textsize var…

### DIFF
--- a/Adafruit_TFTLCD.cpp
+++ b/Adafruit_TFTLCD.cpp
@@ -112,7 +112,7 @@ void Adafruit_TFTLCD::init(void) {
 
   rotation = 0;
   cursor_y = cursor_x = 0;
-  textsize = 1;
+  int textsize = 1;
   textcolor = 0xFFFF;
   _width = TFTWIDTH;
   _height = TFTHEIGHT;


### PR DESCRIPTION
1) The following change has been done to remove the compilation error when using the library due to non-declaration of the datatype for the variable "textsize" used in line 115 of the code.

2) I have added the datatype "int" for the variable since the value assigned to it being 1.

3) Images before & after correction of this issue have also been attached.

![compile_success](https://user-images.githubusercontent.com/32318187/72448669-692bce00-37dd-11ea-8eba-14ed6ed5708a.png)
![error_lcd_library](https://user-images.githubusercontent.com/32318187/72448670-692bce00-37dd-11ea-9505-ed443e377b2c.png)



