### PR TITLE
Enable support for TFTLCD-Library as ESP-IDF component

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.5)
+
+idf_component_register(
+                       SRCS "Adafruit_TFTLCD.cpp"
+                       INCLUDE_DIRS "."
+                       REQUIRES arduino Adafruit-GFX-Library)
+
+project(TFTLCD-Library)


### PR DESCRIPTION
Enables TFTLCD-Library as an ESP-IDF component (with Arduino as component).

This file is based on the CMakeLists.txt file in the Adafruit-GFX-Library repo.